### PR TITLE
Update mailchimp_library.php

### DIFF
--- a/libraries/mailchimp_library.php
+++ b/libraries/mailchimp_library.php
@@ -24,7 +24,9 @@ class Mailchimp_library
         $this->ci->load->config('mailchimp');
 
 		$this->api_key = $this->ci->config->item('api_key');
-		$this->api_endpoint = $this->ci->config->item('api_endpoint');
+		if(strlen(trim($this->ci->config->item('api_endpoint')))>0){
+            		$this->api_endpoint = $this->ci->config->item('api_endpoint');
+        	}
 
 		list(, $datacentre) = explode('-', $this->api_key);
 		$this->api_endpoint = str_replace('<dc>', $datacentre, $this->api_endpoint);


### PR DESCRIPTION
If no endpoint is specified in config files, if is not checked, $this->api_endpoint will be empty.

if(strlen(trim($this->ci->config->item('api_endpoint')))>0){
                    $this->api_endpoint = $this->ci->config->item('api_endpoint');
            }

It checks
